### PR TITLE
Fix ERROR: (gcloud.builds.submit) parsing scripts/cloud-build-demo.yaml

### DIFF
--- a/scripts/cloud-build-demo.yaml
+++ b/scripts/cloud-build-demo.yaml
@@ -36,6 +36,6 @@ steps:
  - name: gcr.io/cloud-builders/gsutil
    args: ['cp', 'normalized_cluster_data.sql', 'gs://${_DATA_STORAGE_BUCKET}/']
  - name: gcr.io/cloud-builders/gsutil
-    args: ['cp', 'gs://df-ml-anomaly-detection-mock-data/*', 'gs://${_DATA_STORAGE_BUCKET}/']
+   args: ['cp', 'gs://df-ml-anomaly-detection-mock-data/*', 'gs://${_DATA_STORAGE_BUCKET}/']
  - name: 'ubuntu'
    args: ['bash', '-c','apt-get -q update && apt-get install -qqy curl; sh df-template.sh ${PROJECT_ID} ${_SUBSCRIPTION_ID} ${_DATASET} ${_DATA_STORAGE_BUCKET} ${_API_KEY}']


### PR DESCRIPTION
Fix the following error.

```
ERROR: (gcloud.builds.submit) parsing scripts/cloud-build-demo.yaml: mapping values are not allowed here   in "scripts/cloud-build-demo.yaml", line 39, column 9
```